### PR TITLE
Hide Sign In / Sign Up links if Memberships are disabled

### DIFF
--- a/partials/navigation.hbs
+++ b/partials/navigation.hbs
@@ -14,12 +14,14 @@
       <button role="link" data-members-signout>Sign out</button>
     </li>
   {{else}}
-    <li class="nav-member-links nav-signin" role="presentation">
-      <a href="{{@site.url}}/signin">Log in</a>
-    </li>
-    <li class="nav-member-links nav-subscribe" role="presentation">
-      <a href="{{@site.url}}/signup">Subscribe</a>
-    </li>
+    {{#if @labs.members}}
+      <li class="nav-member-links nav-signin" role="presentation">
+        <a href="{{@site.url}}/signin">Log in</a>
+      </li>
+      <li class="nav-member-links nav-subscribe" role="presentation">
+        <a href="{{@site.url}}/signup">Subscribe</a>
+      </li>
+    {{/if}}
   {{/if}}
 
 


### PR DESCRIPTION
If Memberships are disabled, those links will lead to non-existing pages, and a user will just see a 404 message.